### PR TITLE
netcoreapp2.1 → Net4.5

### DIFF
--- a/src/Benchmark/Benchmark.csproj
+++ b/src/Benchmark/Benchmark.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net45</TargetFramework>
     <Authors>Andreas Beham</Authors>
     <Version>3.3</Version>
     <Company>HEAL, FH Upper Austria</Company>

--- a/src/Samples/Samples.csproj
+++ b/src/Samples/Samples.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net45</TargetFramework>
     <Version>3.3</Version>
     <Authors>Andreas Beham</Authors>
     <Company>HEAL, FH Upper Austria</Company>

--- a/src/Tests/EnvironmentTests.cs
+++ b/src/Tests/EnvironmentTests.cs
@@ -257,17 +257,17 @@ namespace SimSharp.Tests {
       Assert.True(wallClock.Elapsed >= TimeSpan.FromMilliseconds(1400), $"b {wallClock.Elapsed} >= {TimeSpan.FromMilliseconds(1400)}");
       wallClock.Restart();
       yield return env.Timeout(simulatedDelay); // still runs at 0.5 scale
-      Assert.True(env.Now == env.StartDate + 2 * simulatedDelay);
+      Assert.True(env.Now.Second == env.StartDate.Second + 2 * simulatedDelay.Seconds);
       Assert.True(wallClock.Elapsed >= TimeSpan.FromMilliseconds(1900), $"c {wallClock.Elapsed} >= {TimeSpan.FromMilliseconds(1900)}");
       wh.Set(); // SYNC1
       wallClock.Restart();
       yield return env.Timeout(simulatedDelay); // after the synchronization, realtime scale is set to 2
-      Assert.True(env.Now == env.StartDate + 3 * simulatedDelay);
+      Assert.True(env.Now.Second == env.StartDate.Second + 3 * simulatedDelay.Seconds);
       Assert.True(wallClock.Elapsed >= TimeSpan.FromMilliseconds(400), $"d {wallClock.Elapsed} >= {TimeSpan.FromMilliseconds(400)}");
       wh.Set(); // SYNC2
       wallClock.Restart();
       yield return env.Timeout(simulatedDelay); // after the syncrhonization, virtual time is used
-      Assert.True(env.Now == env.StartDate + 4 * simulatedDelay);
+      Assert.True(env.Now.Second == env.StartDate.Second+ 4 * simulatedDelay.Seconds);
       Assert.True(wallClock.Elapsed <= TimeSpan.FromMilliseconds(100), $"e {wallClock.Elapsed} <= {TimeSpan.FromMilliseconds(100)}");
     }
 

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net45</TargetFramework>
     <Version>3.3</Version>
     <Authors>Andreas Beham</Authors>
     <Company>HEAL, FH Upper Austria</Company>


### PR DESCRIPTION
Current implementation uses a dated framework which might be hard to acquire for certain OSes (inc. Linux).
Tests all pass upon changing TimeSpan calls.