### PR TITLE
Enable SourceLink

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 version: '{build}'
-image: Visual Studio 2017
+image: Visual Studio 2019
 build_script:
 - pwsh: >-
     pushd src

--- a/src/SimSharp/SimSharp.csproj
+++ b/src/SimSharp/SimSharp.csproj
@@ -76,6 +76,9 @@ Sim# allows modeling processes easily and with little boiler plate code. A proce
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <!-- including PDB files in NuGet for source link because symbolsource.org does not support portable PDBs -->
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+  </PropertyGroup>
+   
+  <PropertyGroup Condition="'$(APPVEYOR)' == 'True'">
     <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
   </PropertyGroup>
 

--- a/src/SimSharp/SimSharp.csproj
+++ b/src/SimSharp/SimSharp.csproj
@@ -73,6 +73,10 @@ Sim# allows modeling processes easily and with little boiler plate code. A proce
     <RepositoryUrl>https://github.com/heal-research/SimSharp.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>discrete-event simulation</PackageTags>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <!-- including PDB files in NuGet for source link because symbolsource.org does not support portable PDBs -->
+    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
   </PropertyGroup>
 
   <Target Name="CopyDocumentationFile" AfterTargets="ComputeFilesToPublish">
@@ -87,5 +91,12 @@ Sim# allows modeling processes easily and with little boiler plate code. A proce
 
   <ItemGroup>
     <Service Include="{508349b6-6b84-4df5-91f0-309beebad82d}" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
SourceLink is quite useful for developing dependent applications as it enables users to step into the source code and open definitions of SimSharp through nuget packages. E.g. when opening the definition to a SimSharp class in a dependent project one would then get the code from github instead of getting the decompiled version from the IDE.

I am still quite new to nugets and SourceLink, but I added similar changes that the Newtonsoft repo did when adding this feature (see [this](https://github.com/JamesNK/Newtonsoft.Json/pull/1746) pull request).